### PR TITLE
Implement Django Spectacular for API schema generation and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,17 @@
 ### Setup `.env`
 > To access the secrets, create an .env file in the backend directory
 
+### Set SECRET_KEY
+A SECRET_KEY is mandatory for Django's security features. You can generate one by:
+1. Running this Python command:
+   ```
+   python -c "from django.core.management.utils import get_random_secret_key; print(get_random_secret_key())"
+   ```
+2. Or by typing a long, random string of letters, numbers, and symbols.
+
+Add the generated key to your `.env` file:
+> SECRET_KEY="your_generated_secret_key_here"
+
 ### For Database setup
 By default, django is setup with `sqlite3`. For this project, set `DATABASE_URL` in your `.env` to set the database
 
@@ -44,6 +55,25 @@ Note that four `/` after `sqlite:` are mandatory
 
 
 Navigate to [http://127.0.0.1:8000](http://127.0.0.1:8000)
+
+
+### API Documentation
+
+The API documentation for this project is available using two different interfaces. You can access them when the server is running:
+
+1. Swagger UI:
+   Navigate to [http://127.0.0.1:8000/api/swagger/](http://127.0.0.1:8000/api/swagger/)
+   This provides an interactive interface where you can explore and test the API endpoints.
+
+2. ReDoc:
+   For a more user-friendly, easy-to-read documentation, visit [http://127.0.0.1:8000/api/redoc/](http://127.0.0.1:8000/api/redoc/)
+
+These documentation pages offer:
+- A comprehensive list of all available API endpoints
+- Detailed information about request/response formats
+- The ability to try out API calls directly from the browser (Swagger UI)
+- Authentication requirements for protected endpoints
+- A clear, organized view of the API structure (ReDoc)
 
 
 ## 🖼 Frontend

--- a/backend/api/auth_views.py
+++ b/backend/api/auth_views.py
@@ -1,0 +1,17 @@
+from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
+from drf_spectacular.utils import extend_schema
+
+# We only add tags to the views that are used in the API documentation.
+# The code remains the same as the original implementation.
+
+@extend_schema(
+    summary="Login and return access and refresh tokens",
+    tags=["Authentication"])
+class TaggedTokenObtainPairView(TokenObtainPairView):
+    pass
+
+@extend_schema(
+    summary="Refresh access token",
+    tags=["Authentication"])
+class TaggedTokenRefreshView(TokenRefreshView):
+    pass

--- a/backend/api/settings.py
+++ b/backend/api/settings.py
@@ -60,6 +60,7 @@ THIRD_PARTY_APPS = [
     "rest_framework_simplejwt",
     "rest_framework_simplejwt.token_blacklist",
     "corsheaders",
+    "drf_spectacular",
 ]
 
 LOCAL_APPS = [
@@ -73,6 +74,7 @@ INSTALLED_APPS = DJANGO_APPS + THIRD_PARTY_APPS + LOCAL_APPS
 
 # Settings for Django Rest Framework
 REST_FRAMEWORK = {
+    "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
     "DEFAULT_PERMISSION_CLASSES": [
         "rest_framework.permissions.IsAuthenticatedOrReadOnly",
     ],
@@ -210,3 +212,20 @@ CORS_ALLOWED_ORIGINS = [
     "http://localhost:4200",
     "http://localhost:8000",
     ]
+
+SPECTACULAR_SETTINGS = {
+    'TITLE': 'Virtual Marketplace API',
+    'DESCRIPTION': 'API for Virtual Marketplace',
+    'VERSION': '1.0.0',
+    'SERVE_INCLUDE_SCHEMA': False,
+    'TAGS': [
+        {'name': 'Users', 'description': 'User management operations'},
+        {'name': 'Authentication', 'description': 'Authentication operations'},
+        {'name': 'Addresses', 'description': 'Address management operations'},
+        {'name': 'Favorites', 'description': 'Favorite management operations'},
+        {'name': 'Reviews', 'description': 'Review management operations'},
+        {'name': 'Listings', 'description': 'Listing management operations'},
+        {'name': 'Transactions', 'description': 'Transaction management operations'},
+    ],
+}
+

--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -1,12 +1,20 @@
+from django.conf import settings
+from django.conf.urls.static import static
 from django.urls import path, include
-from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
+from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView, SpectacularRedocView
+from .auth_views import TaggedTokenObtainPairView, TaggedTokenRefreshView
 
 urlpatterns = [
     path('api/', include([
         path('', include('users.urls')),
         path('', include('listings.urls')),
         path('', include('orders.urls')),
-        path('token/', TokenObtainPairView.as_view(), name='token_obtain_pair'),
-        path('token/refresh/', TokenRefreshView.as_view(), name='token_refresh'),
+        path('token/', TaggedTokenObtainPairView.as_view(), name='token_obtain_pair'),
+        path('token/refresh/', TaggedTokenRefreshView.as_view(), name='token_refresh'),
+        path('schema/', SpectacularAPIView.as_view(), name='schema'),
+        path('swagger/', SpectacularSwaggerView.as_view(url_name='schema'), name='swagger-ui'),
+        path('redoc/', SpectacularRedocView.as_view(url_name='schema'), name='redoc'),
     ])),
 ]
+
+

--- a/backend/listings/views.py
+++ b/backend/listings/views.py
@@ -1,25 +1,146 @@
 from .models import *
 from .serializers import *
 from rest_framework import viewsets
+from drf_spectacular.utils import extend_schema, extend_schema_view
 
 from rest_framework.permissions import IsAuthenticated, IsAdminUser, IsAuthenticatedOrReadOnly
 from rest_framework.authentication import SessionAuthentication, BasicAuthentication, TokenAuthentication
 
-
+@extend_schema_view(
+    list=extend_schema(
+        summary="List all listings",
+        description="Returns a list of all listings in the system.",
+        responses={200: ListingSerializer(many=True)},
+        tags=["Listings"]
+    ),
+    create=extend_schema(
+        summary="Create a new listing",
+        description="Create a new listing.",
+        request=ListingSerializer,
+        responses={201: ListingSerializer},
+        tags=["Listings"]
+    ),
+    retrieve=extend_schema(
+        summary="Get a listing by ID",
+        description="Retrieve a listing by its ID.",
+        responses={200: ListingSerializer},
+        tags=["Listings"]
+    ),
+    update=extend_schema(
+        summary="Update a listing",
+        description="Update a listing by its ID.",
+        request=ListingSerializer,
+        responses={200: ListingSerializer},
+        tags=["Listings"]
+    ),
+    partial_update=extend_schema(
+        summary="Partially update a listing",
+        description="Partially update a listing by its ID.",
+        request=ListingSerializer,
+        responses={200: ListingSerializer},
+        tags=["Listings"]
+    ),
+    destroy=extend_schema(
+        summary="Delete a listing",
+        description="Delete a listing by its ID.",
+        responses={204: None},
+        tags=["Listings"]
+    )
+)
 class ListingViewSet(viewsets.ModelViewSet):
     queryset = Listing.objects.all()
     serializer_class = ListingSerializer
     authentication_classes = [TokenAuthentication, SessionAuthentication, BasicAuthentication]
     permission_classes = [IsAuthenticated]
 
-
+@extend_schema_view(
+    list=extend_schema(
+        summary="List all categories",
+        description="Returns a list of all categories in the system.",
+        responses={200: CategorySerializer(many=True)},
+        tags=["Categories"]
+    ),
+    create=extend_schema(
+        summary="Create a new category",    
+        description="Create a new category.",
+        request=CategorySerializer,
+        responses={201: CategorySerializer},
+        tags=["Categories"]
+    ),
+    retrieve=extend_schema(
+        summary="Get a category by ID",
+        description="Retrieve a category by its ID.",   
+        responses={200: CategorySerializer},
+        tags=["Categories"]
+    ),
+    update=extend_schema(
+        summary="Update a category",
+        description="Update a category by its ID.",
+        request=CategorySerializer,
+        responses={200: CategorySerializer},                    
+        tags=["Categories"]
+    ),
+    partial_update=extend_schema(
+        summary="Partially update a category",
+        description="Partially update a category by its ID.",
+        request=CategorySerializer,
+        responses={200: CategorySerializer},
+        tags=["Categories"]
+    ),
+    destroy=extend_schema(
+        summary="Delete a category",
+        description="Delete a category by its ID.",
+        responses={204: None},
+        tags=["Categories"]
+    )
+)
 class CategoryViewSet(viewsets.ModelViewSet):
     queryset = Category.objects.all()
     serializer_class = CategorySerializer
     authentication_classes = [TokenAuthentication, SessionAuthentication, BasicAuthentication]
     permission_classes = [IsAdminUser]
 
-
+@extend_schema_view(
+    list=extend_schema(
+        summary="List all favorites",
+        description="Returns a list of all favorites for the authenticated user.",
+        responses={200: FavoriteSerializer(many=True)},
+        tags=["Favorites"]
+    ),
+    create=extend_schema(
+        summary="Create a new favorite",    
+        description="Create a new favorite for the authenticated user.",
+        request=FavoriteSerializer,
+        responses={201: FavoriteSerializer},
+        tags=["Favorites"]
+    ),
+    retrieve=extend_schema(
+        summary="Get a favorite by ID",
+        description="Retrieve a favorite by its ID for the authenticated user.",   
+        responses={200: FavoriteSerializer},
+        tags=["Favorites"]
+    ),
+    update=extend_schema(
+        summary="Update a favorite",
+        description="Update a favorite by its ID for the authenticated user.",
+        request=FavoriteSerializer,
+        responses={200: FavoriteSerializer},    
+        tags=["Favorites"]
+    ),
+    partial_update=extend_schema(
+        summary="Partially update a favorite",
+        description="Partially update a favorite by its ID for the authenticated user.",
+        request=FavoriteSerializer,
+        responses={200: FavoriteSerializer},
+        tags=["Favorites"]
+    ),
+    destroy=extend_schema(
+        summary="Delete a favorite",
+        description="Delete a favorite by its ID for the authenticated user.",
+        responses={204: None},
+        tags=["Favorites"]
+    )
+)
 class FavoriteViewSet(viewsets.ModelViewSet):
     queryset = Favorite.objects.all()
     serializer_class = FavoriteSerializer

--- a/backend/orders/views.py
+++ b/backend/orders/views.py
@@ -1,25 +1,189 @@
 from django.shortcuts import render
 from rest_framework import viewsets
+from drf_spectacular.utils import extend_schema, extend_schema_view
 from .models import *
 from .serializers import *
 
 
-# Create your views here.
+@extend_schema_view(
+    list=extend_schema(
+        summary="List all transactions",
+        description="Returns a list of all transactions in the system.",
+        responses={200: TransactionSerializer(many=True)},
+        tags=["Transactions"]
+    ),
+    create=extend_schema(
+        summary="Create a new transaction",
+        description="Create a new transaction(order)",
+        request=TransactionSerializer,
+        responses={201: TransactionSerializer},
+        tags=["Transactions"]
+    ),
+    retrieve=extend_schema(
+        summary="Get a transaction by ID",
+        description="Retrieve a transaction by its ID.",
+        responses={200: TransactionSerializer},
+        tags=["Transactions"]
+    ),
+    update=extend_schema(
+        summary="Update a transaction",
+        description="Update a transaction by its ID.",
+        request=TransactionSerializer,
+        responses={200: TransactionSerializer},
+        tags=["Transactions"]
+    ),
+    partial_update=extend_schema(
+        summary="Partially update a transaction",
+        description="Partially update a transaction by its ID.",
+        request=TransactionSerializer,
+        responses={200: TransactionSerializer},
+        tags=["Transactions"]
+    ),
+    destroy=extend_schema(
+        summary="Delete a transaction",
+        description="Delete a transaction by its ID.",
+        responses={204: None},
+        tags=["Transactions"]
+    )
+)
 class TransactionViewSet(viewsets.ModelViewSet):
     queryset = Transaction.objects.all()
     serializer_class = TransactionSerializer
 
 
+@extend_schema_view(
+    list=extend_schema(
+        summary="List all carts",
+        description="Returns a list of all carts in the system.",
+        responses={200: CartSerializer(many=True)},
+        tags=["Carts"]
+    ),
+    create=extend_schema(
+        summary="Create a new cart",
+        description="Create a new cart for a user.",
+        request=CartSerializer,
+        responses={201: CartSerializer},
+        tags=["Carts"]
+    ),
+    retrieve=extend_schema(
+        summary="Get a cart by ID",
+        description="Retrieve a cart by its ID.",
+        responses={200: CartSerializer},
+        tags=["Carts"]
+    ),
+    update=extend_schema(
+        summary="Update a cart",
+        description="Update a cart by its ID.",
+        request=CartSerializer,
+        responses={200: CartSerializer},
+        tags=["Carts"]
+    ),
+    partial_update=extend_schema(
+        summary="Partially update a cart",
+        description="Partially update a cart by its ID.",
+        request=CartSerializer,
+        responses={200: CartSerializer},
+        tags=["Carts"]
+    ),
+    destroy=extend_schema(
+        summary="Delete a cart",
+        description="Delete a cart by its ID.",
+        responses={204: None},
+        tags=["Carts"]
+    )
+)
 class CartViewSet(viewsets.ModelViewSet):
     queryset = Cart.objects.all()
     serializer_class = CartSerializer
 
 
+@extend_schema_view(
+    list=extend_schema(
+        summary="List all cart items",
+        description="Returns a list of all cart items in the system.",
+        responses={200: CartItemSerializer(many=True)},
+        tags=["Cart Items"]
+    ),
+    create=extend_schema(
+        summary="Create a new cart item",
+        description="Create a new cart item for a cart.",
+        request=CartItemSerializer,
+        responses={201: CartItemSerializer},
+        tags=["Cart Items"]
+    ),
+    retrieve=extend_schema(
+        summary="Get a cart item by ID",
+        description="Retrieve a cart item by its ID.",
+        responses={200: CartItemSerializer},
+        tags=["Cart Items"]
+    ),
+    update=extend_schema(
+        summary="Update a cart item",
+        description="Update a cart item by its ID.",
+        request=CartItemSerializer,
+        responses={200: CartItemSerializer},
+        tags=["Cart Items"]
+    ),
+    partial_update=extend_schema(
+        summary="Partially update a cart item",
+        description="Partially update a cart item by its ID.",
+        request=CartItemSerializer,
+        responses={200: CartItemSerializer},
+        tags=["Cart Items"]
+    ),
+    destroy=extend_schema(
+        summary="Delete a cart item",
+        description="Delete a cart item by its ID.",
+        responses={204: None},
+        tags=["Cart Items"]
+    )
+)
 class CartItemViewSet(viewsets.ModelViewSet):
     queryset = CartItem.objects.all()
     serializer_class = CartItemSerializer
 
 
+@extend_schema_view(
+    list=extend_schema(
+        summary="List all coupons",
+        description="Returns a list of all coupons in the system.",
+        responses={200: CouponSerializer(many=True)},
+        tags=["Coupons"]
+    ),
+    create=extend_schema(   
+        summary="Create a new coupon",
+        description="Create a new coupon.",
+        request=CouponSerializer,
+        responses={201: CouponSerializer},
+        tags=["Coupons"]
+    ),
+    retrieve=extend_schema(
+        summary="Get a coupon by ID",
+        description="Retrieve a coupon by its ID.",
+        responses={200: CouponSerializer},
+        tags=["Coupons"]
+    ),
+    update=extend_schema(
+        summary="Update a coupon",
+        description="Update a coupon by its ID.",
+        request=CouponSerializer,
+        responses={200: CouponSerializer},
+        tags=["Coupons"]
+    ),
+    partial_update=extend_schema(
+        summary="Partially update a coupon",
+        description="Partially update a coupon by its ID.",
+        request=CouponSerializer,
+        responses={200: CouponSerializer},
+        tags=["Coupons"]
+    ),
+    destroy=extend_schema(
+        summary="Delete a coupon",
+        description="Delete a coupon by its ID.",
+        responses={204: None},
+        tags=["Coupons"]
+    )
+)
 class CouponViewSet(viewsets.ModelViewSet):
     queryset = Coupon.objects.all()
     serializer_class = CouponSerializer

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -13,6 +13,7 @@ PyJWT==2.8.0
 sqlparse==0.5.1
 tomli==2.0.1
 typing_extensions==4.12.2
-pytest-django==8.3.3
+pytest-django==4.9.0
 django-environ==0.11.2
 django-cors-headers==4.4.0
+drf-spectacular==0.27.2

--- a/backend/users/auth_views.py
+++ b/backend/users/auth_views.py
@@ -14,6 +14,8 @@ from rest_framework_simplejwt.tokens import RefreshToken
 from rest_framework_simplejwt.views import TokenRefreshView
 # from rest_framework_simplejwt.serializers import  TokenBlacklistSerializer
 from rest_framework_simplejwt.exceptions import TokenError, InvalidToken
+from drf_spectacular.utils import extend_schema, OpenApiResponse, OpenApiExample
+from drf_spectacular.types import OpenApiTypes
 
 from .serializers import LoginSerializer, RegisterSerializer
 from core.common import responseMessages
@@ -25,6 +27,13 @@ __all__ = ['LoginView', 'RegisterView', 'RefreshTokenView']
 
 
 @method_decorator(sensitive_post_parameters('password'), name="dispatch")
+@extend_schema(
+    summary="Login",
+    description="Login a user.",
+    request=LoginSerializer,
+    responses={200: LoginSerializer},
+    tags=["Authentication"]
+)
 class LoginView(APIView):
     permission_classes = []
     authentication_classes = []
@@ -53,6 +62,13 @@ class LoginView(APIView):
 
 
 @method_decorator(sensitive_post_parameters('password', 'confirm_password'), name="dispatch")
+@extend_schema(
+    summary="Register",
+    description="Register a new user.",
+    request=RegisterSerializer,
+    responses={201: RegisterSerializer},
+    tags=["Authentication"]
+)
 class RegisterView(APIView):
     permission_classes = []
     authentication_classes = []
@@ -71,7 +87,11 @@ class RegisterView(APIView):
 
         return Response(response_data, status=response_status)
 
-
+@extend_schema(
+    summary="Refresh Token",
+    description="Refresh the access token using the refresh token.",
+    tags=["Authentication"]
+)
 class RefreshTokenView(TokenRefreshView):
     """ overriding default refresh token view
     """
@@ -100,16 +120,39 @@ class RefreshTokenView(TokenRefreshView):
             logger.error(str(exe), exc_info=True)
             raise APIException(exe.detail)
 
-
 class LogoutView(APIView):
     permission_classes = [IsAuthenticated]
 
-    def post(self, request, format=None):
+    @extend_schema(
+        summary="Logout",
+        description="Logout the authenticated user by blacklisting their refresh token.",
+        tags=["Authentication"],
+        request=OpenApiTypes.NONE,  # No request body needed
+        responses={
+            200: OpenApiTypes.OBJECT,
+            400: OpenApiTypes.OBJECT,
+        },
+        examples=[
+            OpenApiExample(
+                'Successful Response',
+                value={'detail': 'User logout successfully.'},
+                response_only=True,
+                status_codes=['200']
+            ),
+            OpenApiExample(
+                'Error Response',
+                value={'detail': 'Error message'},
+                response_only=True,
+                status_codes=['400']
+            ),
+        ]
+    )
+    def post(self, request):
         try:
             token = get_refresh_token(request)
             old_refresh = RefreshToken(token)
             old_refresh.blacklist()
-            return handle_success_response(None, 'User logout successfully.')
+            return Response({"detail": "User logout successfully."}, status=status.HTTP_200_OK)
 
         except APIException as exe:
             logger.error(str(exe), exc_info=True)

--- a/backend/users/views.py
+++ b/backend/users/views.py
@@ -1,36 +1,162 @@
 # Rest
 from rest_framework import viewsets, permissions
+from drf_spectacular.utils import extend_schema, OpenApiParameter, extend_schema_view
 
 # Local
 from .permissions import IsOwnerOrReadOnly, IsAllowedToReview, IsAllowedToDestroyReview
 from .serializers import *
+from .models import User
 
 
+@extend_schema_view(
+    list=extend_schema(
+        summary="List all users",
+        description="Returns a list of all active users in the system.",
+        parameters=[
+            OpenApiParameter(
+                name='username', description='Filter by username', required=False, type=str),
+        ],
+        responses={200: UserSerializer(many=True)},
+        tags=["Users"]
+    ),
+    retrieve=extend_schema(
+        summary="Retrieve a user",
+        description="Get details of a specific user by ID.",
+        tags=["Users"]
+    ),
+)
 class UserViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = User.objects.all()
     serializer_class = UserSerializer
 
 
+@extend_schema_view(
+    list=extend_schema(
+        summary="List all addresses",
+        description="Returns a list of all addresses in the system.",
+        responses={200: AddressSerializer(many=True)},
+        tags=["Addresses"]
+    ),
+    create=extend_schema(
+        summary="Create a new address",
+        description="Create a new address for the authenticated user.",
+        request=AddressSerializer,
+        responses={201: AddressSerializer},
+        tags=["Addresses"]
+    ),
+    retrieve=extend_schema(
+        summary="Retrieve an address",
+        description="Get details of a specific address by ID.",
+        tags=["Addresses"]
+    ),
+    update=extend_schema(
+        summary="Update an address",
+        description="Update details of a specific address by ID.",
+        tags=["Addresses"]
+    ),
+    partial_update=extend_schema(
+        summary="Partially update an address",
+        description="Partially update details of a specific address by ID.",
+        tags=["Addresses"]
+    ),
+    destroy=extend_schema(
+        summary="Delete an address",
+        description="Delete a specific address by ID.",
+        tags=["Addresses"]
+    )
+)
 class AddressViewSet(viewsets.ModelViewSet):
     queryset = Address.objects.all()
     serializer_class = AddressSerializer
-
-    permission_classes = [permissions.IsAuthenticatedOrReadOnly, IsOwnerOrReadOnly]
+    permission_classes = [
+        permissions.IsAuthenticatedOrReadOnly, IsOwnerOrReadOnly]
 
     def perform_create(self, serializer):
         serializer.save(user=self.request.user)
 
 
+@extend_schema_view(
+    list=extend_schema(
+        summary="List all favorites",
+        description="Returns a list of all favorites for the authenticated user.",
+        responses={200: FavoriteSerializer(many=True)},
+        tags=["Favorites"]
+    ),
+    create=extend_schema(
+        summary="Create a new favorite",
+        description="Create a new favorite for the authenticated user.",
+        request=FavoriteSerializer,
+        responses={201: FavoriteSerializer},
+        tags=["Favorites"]
+    ),
+    retrieve=extend_schema(
+        summary="Retrieve a favorite",
+        description="Get details of a specific favorite by ID.",
+        tags=["Favorites"]
+    ),
+    update=extend_schema(
+        summary="Update a favorite",
+        description="Update details of a specific favorite by ID.",
+        tags=["Favorites"]
+    ),
+    partial_update=extend_schema(
+        summary="Partially update a favorite",
+        description="Partially update details of a specific favorite by ID.",
+        tags=["Favorites"]
+    ),
+    destroy=extend_schema(
+        summary="Delete a favorite",
+        description="Delete a specific favorite by ID.",
+        tags=["Favorites"]
+    ),
+)
 class FavoriteViewSet(viewsets.ModelViewSet):
     queryset = Favorite.objects.all()
     serializer_class = FavoriteSerializer
-    permission_classes = [permissions.IsAuthenticatedOrReadOnly, IsOwnerOrReadOnly]
+    permission_classes = [
+        permissions.IsAuthenticatedOrReadOnly, IsOwnerOrReadOnly]
 
     def perform_create(self, serializer):
         serializer.save(user=self.request.user)
 
 
+@extend_schema_view(
+    list=extend_schema(
+        summary="List all reviews",
+        description="Returns a list of all reviews in the system.",
+        responses={200: ReviewSerializer(many=True)},
+        tags=["Reviews"]
+    ),
+    create=extend_schema(
+        summary="Create a new review",
+        description="Create a new review for a product or service.",
+        request=ReviewSerializer,
+        responses={201: ReviewSerializer},
+        tags=["Reviews"]
+    ),
+    retrieve=extend_schema(
+        summary="Retrieve a review",
+        description="Get details of a specific review by ID.",
+        tags=["Reviews"]
+    ),
+    update=extend_schema(
+        summary="Update a review",
+        description="Update details of a specific review by ID.",
+        tags=["Reviews"]
+    ),
+    partial_update=extend_schema(
+        summary="Partially update a review",
+        description="Partially update details of a specific review by ID.",
+        tags=["Reviews"]
+    ),
+    destroy=extend_schema(
+        summary="Delete a review",
+        description="Delete a specific review by ID.",
+        tags=["Reviews"]
+    ),
+)
 class ReviewViewSet(viewsets.ModelViewSet):
     queryset = Review.objects.all()
     serializer_class = ReviewSerializer
-    permission_classes = [permissions.IsAuthenticatedOrReadOnly, IsAllowedToReview, IsAllowedToDestroyReview]
+    permission_classes = [permissions.IsAuthenticatedOrReadOnly,
+                          IsAllowedToReview, IsAllowedToDestroyReview]


### PR DESCRIPTION
- Integrated Django Spectacular for API schema generation and documentation
- Added documentation for all endpoints using @extend_schema decorators
- Grouped authentication endpoints (including token operations) under the "Authentication" tag
- Redefined token obtain and refresh views to include them in API documentation
- Added Swagger UI and ReDoc views for API exploration
  - API documentation now available through /api/swagger/ or /api/redoc/
- Updated settings to configure Django Spectacular
- Improved error handling and response examples for authentication views
- Ensured consistent tagging across all API endpoints for better organization
- Fixed pytest version in requirements.txt to resolve compatibility issues

This commit introduces API documentation to the project, making the API
structure and endpoints more visible and understandable. It enhances the
developer experience by providing clear, grouped endpoints in both 
Swagger UI and ReDoc interfaces.

The addition of ReDoc provides an alternative, user-friendly interface for
API documentation, complementing the Swagger UI.